### PR TITLE
feat: middlewares added

### DIFF
--- a/internal/middlewares/logging/logging.go
+++ b/internal/middlewares/logging/logging.go
@@ -1,0 +1,23 @@
+package logging
+
+import (
+	"log"
+	"maps"
+	"net/http"
+	"net/http/httptest"
+)
+
+func HttpLogger(fn http.HandlerFunc) http.HandlerFunc {
+	return func (w http.ResponseWriter, r *http.Request) {
+		recorder := httptest.NewRecorder()
+		fn(recorder, r)
+
+		log.Printf("%s %s - %d", r.Method, r.URL.Path, recorder.Code)
+
+		maps.Copy(w.Header(), recorder.Result().Header)
+		_, err := recorder.Body.WriteTo(w)
+		if err!=nil {
+			log.Fatalf("HttpLogger write to response body error: %v", err)
+		}
+	}
+}

--- a/internal/middlewares/logging/logging.go
+++ b/internal/middlewares/logging/logging.go
@@ -5,19 +5,23 @@ import (
 	"maps"
 	"net/http"
 	"net/http/httptest"
+
+	"github.com/Arup3201/gotasks/internal/middlewares"
 )
 
-func HttpLogger(fn http.HandlerFunc) http.HandlerFunc {
-	return func (w http.ResponseWriter, r *http.Request) {
-		recorder := httptest.NewRecorder()
-		fn(recorder, r)
+func HttpLogger() middlewares.Middleware {
+	return func (fn http.HandlerFunc) http.HandlerFunc {
+		return func (w http.ResponseWriter, r *http.Request) {
+			recorder := httptest.NewRecorder()
+			fn(recorder, r)
 
-		log.Printf("%s %s - %d", r.Method, r.URL.Path, recorder.Code)
+			log.Printf("%s %s - %d", r.Method, r.URL.Path, recorder.Code)
 
-		maps.Copy(w.Header(), recorder.Result().Header)
-		_, err := recorder.Body.WriteTo(w)
-		if err!=nil {
-			log.Fatalf("HttpLogger write to response body error: %v", err)
+			maps.Copy(w.Header(), recorder.Result().Header)
+			_, err := recorder.Body.WriteTo(w)
+			if err!=nil {
+				log.Fatalf("HttpLogger write to response body error: %v", err)
+			}
 		}
 	}
 }

--- a/internal/middlewares/methods/methods.go
+++ b/internal/middlewares/methods/methods.go
@@ -1,0 +1,22 @@
+package methods
+
+import (
+	"log"
+	"net/http"
+	"slices"
+
+	"github.com/Arup3201/gotasks/internal/middlewares"
+)
+
+func Methods(methods []string) middlewares.Middleware {
+	return func (fn http.HandlerFunc) http.HandlerFunc {
+		return func (w http.ResponseWriter, r *http.Request) {
+			if slices.Contains(methods, r.Method) {
+				fn(w, r)
+			} else {
+				log.Printf("%s %s - %d", r.Method, r.URL.Path, http.StatusForbidden)
+				log.Printf("[SERVER] Method not allowed")
+			}
+		}
+	}
+}

--- a/internal/middlewares/middlewares.go
+++ b/internal/middlewares/middlewares.go
@@ -1,0 +1,13 @@
+package middlewares
+
+import "net/http"
+
+type Middleware func(http.HandlerFunc) http.HandlerFunc
+
+func Chain(fn http.HandlerFunc, middlewares ...Middleware) http.HandlerFunc {
+	for _, m := range middlewares {
+		fn = m(fn)
+	}
+
+	return fn
+}


### PR DESCRIPTION
**Changes**
- added `Middleware` type to build middlewares
- added `Chain` method to chain multiple middlewares to a handler function
- added `HttpLogger` middleware for logging http requests
- added `Methods` middleware for filtering only allowed methods

**Middleware Usage**

```go
package main

import (
	"fmt"
	"log"
	"net/http"

	"github.com/Arup3201/gotasks/internal/middlewares"
	"github.com/Arup3201/gotasks/internal/middlewares/logging"
	"github.com/Arup3201/gotasks/internal/middlewares/methods"
)

const PORT = ":8000"

func index(w http.ResponseWriter, r *http.Request) {
	fmt.Fprintf(w, "Hello, world!\n")
}

func main() {
	http.HandleFunc("/", middlewares.Chain(index, logging.HttpLogger(), methods.Methods([]string{"GET", "POST"})))


	log.Printf("Starting the server at %s\n", PORT)
	log.Fatal(http.ListenAndServe(PORT, nil))
}
```

**Requests**

```sh
$ curl localhost:8000
$ curl -X POST localhost:8000
curl -X PUT localhost:8000
```

**Responses**

```sh
2025/09/04 16:35:31 Starting the server at :8000
2025/09/04 16:35:44 GET / - 200
2025/09/04 16:35:56 POST / - 200
2025/09/04 16:36:01 PUT / - 403
2025/09/04 16:36:01 [SERVER] Method not allowed
```