### PR TITLE
fix: /task pattern matched with multiple handler functions

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -13,9 +13,16 @@ import (
 const PORT = ":8000"
 
 func main() {
-	http.HandleFunc("/tasks", middlewares.Chain(handlers.GetTasks, logging.HttpLogger(), methods.Methods([]string{"GET"})))
-	http.HandleFunc("/tasks", middlewares.Chain(handlers.AddTask, logging.HttpLogger(), methods.Methods([]string{"POST"})))
-	http.HandleFunc("/tasks", middlewares.Chain(handlers.EditTask, logging.HttpLogger(), methods.Methods([]string{"PUT"})))
+	http.HandleFunc("/tasks", middlewares.Chain(methods.Map([]methods.MethodHandler{
+		{
+			Handler: handlers.GetTasks,
+			Method:  "GET",
+		},
+		{
+			Handler: handlers.AddTask,
+			Method:  "POST",
+		},
+	}), logging.HttpLogger()))
 
 	log.Printf("Starting the server at %s\n", PORT)
 	log.Fatal(http.ListenAndServe(PORT, nil))

--- a/internal/middlewares/methods/methods.go
+++ b/internal/middlewares/methods/methods.go
@@ -3,20 +3,26 @@ package methods
 import (
 	"log"
 	"net/http"
-	"slices"
-
-	"github.com/Arup3201/gotasks/internal/middlewares"
 )
 
-func Methods(methods []string) middlewares.Middleware {
-	return func (fn http.HandlerFunc) http.HandlerFunc {
-		return func (w http.ResponseWriter, r *http.Request) {
-			if slices.Contains(methods, r.Method) {
-				fn(w, r)
-			} else {
-				log.Printf("%s %s - %d", r.Method, r.URL.Path, http.StatusForbidden)
-				log.Printf("[SERVER] Method not allowed")
+type MethodHandler struct {
+	Handler http.HandlerFunc
+	Method  string
+}
+
+func Map(mHandles []MethodHandler) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		matched := false
+		for _, mHandle := range mHandles {
+			if r.Method == mHandle.Method {
+				mHandle.Handler(w, r)
+				matched = true
 			}
+		}
+
+		if !matched {
+			log.Printf("%s %s - %d", r.Method, r.URL.Path, http.StatusForbidden)
+			log.Printf("[SERVER] Method not allowed")
 		}
 	}
 }


### PR DESCRIPTION
**Changes**

- fix: `/tasks` pattern is matched with multiple handler functions
- feat: `Map` middleware added to map multiple handlers to a method

**Usage**

```go
func main() {
	http.HandleFunc("/tasks", middlewares.Chain(methods.Map([]methods.MethodHandler{
		{
			Handler: handlers.GetTasks,
			Method:  "GET",
		},
		{
			Handler: handlers.AddTask,
			Method:  "POST",
		},
	}), logging.HttpLogger()))

	log.Printf("Starting the server at %s\n", PORT)
	log.Fatal(http.ListenAndServe(PORT, nil))
}
```