### PR TITLE
fix: potential multiple rewrites in Map middleware

### DIFF
--- a/internal/middlewares/logging/logging.go
+++ b/internal/middlewares/logging/logging.go
@@ -10,16 +10,17 @@ import (
 )
 
 func HttpLogger() middlewares.Middleware {
-	return func (fn http.HandlerFunc) http.HandlerFunc {
-		return func (w http.ResponseWriter, r *http.Request) {
+	return func(fn http.HandlerFunc) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
 			recorder := httptest.NewRecorder()
 			fn(recorder, r)
 
 			log.Printf("%s %s - %d", r.Method, r.URL.Path, recorder.Code)
 
+			w.WriteHeader(recorder.Result().StatusCode)
 			maps.Copy(w.Header(), recorder.Result().Header)
 			_, err := recorder.Body.WriteTo(w)
-			if err!=nil {
+			if err != nil {
 				log.Fatalf("HttpLogger write to response body error: %v", err)
 			}
 		}

--- a/internal/middlewares/methods/methods.go
+++ b/internal/middlewares/methods/methods.go
@@ -1,7 +1,6 @@
 package methods
 
 import (
-	"log"
 	"net/http"
 )
 
@@ -22,7 +21,6 @@ func Map(mHandles []MethodHandler) http.HandlerFunc {
 		}
 
 		if !matched {
-			log.Printf("%s %s - %d", r.Method, r.URL.Path, http.StatusMethodNotAllowed)
 			w.WriteHeader(http.StatusMethodNotAllowed)
 		}
 	}


### PR DESCRIPTION
**Changes**

- fix: avoid potential multiple rewrites by breaking the loop at `Map`
- fix: method mismatch http error should be method not allowed
- fix: method mismatch does not write error to client response
- fix: `HttpLogger` not propagating the response status when method mismatches