### PR TITLE
feat: handling error for adding task with missing title or description

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -1,14 +1,50 @@
 package main
 
 import (
+	"log"
+	"net/http"
+
+	"github.com/Arup3201/gotasks/internal/errors"
 	"github.com/Arup3201/gotasks/internal/handlers"
 	"github.com/gin-gonic/gin"
 )
+
+func HandleErrors() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Next()
+
+		if len(c.Errors) > 0 {
+			err := c.Errors.Last().Err
+
+			clientError, ok := err.(errors.ClientError)
+			if !ok {
+				c.IndentedJSON(http.StatusInternalServerError, gin.H{"message": "An unexpected error occured"})
+				return
+			}
+
+			body, err := clientError.ResponseBody()
+			if err != nil {
+				log.Printf("ClientError.ResponseBody error: %v", err)
+				c.IndentedJSON(http.StatusInternalServerError, gin.H{"message": "An unexpected error occured"})
+				return
+			}
+
+			status, headers := clientError.ResponseHeader()
+			for k, v := range headers {
+				c.Writer.Header().Set(k, v)
+			}
+			c.Writer.WriteHeader(status)
+			c.Writer.Write(body)
+		}
+	}
+}
 
 const PORT = ":8000"
 
 func main() {
 	router := gin.Default()
+
+	router.Use(HandleErrors())
 
 	router.GET("/tasks", handlers.GetAllTasks)
 	router.POST("/tasks", handlers.AddTask)

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -1,0 +1,18 @@
+package errors
+
+type ClientError interface {
+	Error() string
+	// ResponseBody returns response body of the error
+	ResponseBody() ([]byte, error)
+	// ResponseHeader returns status code and response headers of the error
+	ResponseHeader() (int, map[string]string)
+}
+
+type BaseError struct {
+	Type   string `json:"type"`
+	Title  string `json:"title"`
+	Detail string `json:"detail"`
+	Status int    `json:"status"`
+	Code   string `json:"code"`
+	Cause  error  `json:"-"`
+}

--- a/internal/errors/missing-body.go
+++ b/internal/errors/missing-body.go
@@ -1,0 +1,52 @@
+package errors
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type ErrorDetail struct {
+	Detail  string `json:"detail"`
+	Pointer string `json:"pointer"`
+}
+
+type MissingBodyPropertyError struct {
+	BaseError
+	Errors []ErrorDetail `json:"errors"`
+}
+
+func (e *MissingBodyPropertyError) Error() string {
+	if e.Cause == nil {
+		return e.Detail
+	}
+
+	return e.Detail + ": " + e.Cause.Error()
+}
+
+func (e *MissingBodyPropertyError) ResponseBody() ([]byte, error) {
+	body, err := json.Marshal(e)
+	if err != nil {
+		return nil, fmt.Errorf("Error while parsing response body: %v", err)
+	}
+
+	return body, nil
+}
+
+func (e *MissingBodyPropertyError) ResponseHeader() (int, map[string]string) {
+	return e.Status, map[string]string{
+		"Content-Type": "application/problem+json; charset=utf-8",
+	}
+}
+
+func NewMissingBodyProperyError(err error, errors []ErrorDetail) error {
+	return &MissingBodyPropertyError{
+		BaseError: BaseError{
+			Type:   "https://problems-registry.smartbear.com/missing-body-property",
+			Title:  "Missing body property",
+			Detail: "The request is missing an expected body property.",
+			Status: 400,
+			Code:   "400-09",
+		},
+		Errors: errors,
+	}
+}

--- a/internal/handlers/tasks.go
+++ b/internal/handlers/tasks.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/Arup3201/gotasks/internal/errors"
 	"github.com/Arup3201/gotasks/internal/models"
 	"github.com/Arup3201/gotasks/internal/storage"
 	"github.com/Arup3201/gotasks/internal/utils"
@@ -21,7 +22,6 @@ func GetTaskWithId(c *gin.Context) {
 
 	task, ok := storage.GetTaskWithId(id)
 	if !ok {
-		c.IndentedJSON(http.StatusNotFound, gin.H{"message": fmt.Sprintf("Task with ID '%s' not found", id)})
 		return
 	}
 
@@ -36,10 +36,30 @@ func AddTask(c *gin.Context) {
 		return
 	}
 
+	if payload.Title == nil {
+		c.Error(errors.NewMissingBodyProperyError(nil, []errors.ErrorDetail{
+			{
+				Detail:  "The body property 'title' is required",
+				Pointer: "#/title",
+			},
+		}))
+		return
+	}
+
+	if payload.Description == nil {
+		c.Error(errors.NewMissingBodyProperyError(nil, []errors.ErrorDetail{
+			{
+				Detail:  "The body property 'description' is required",
+				Pointer: "#/description",
+			},
+		}))
+		return
+	}
+
 	newTask := models.Task{
 		Id:          utils.GenerateID("TASK_"),
-		Title:       payload.Title,
-		Description: payload.Description,
+		Title:       *payload.Title,
+		Description: *payload.Description,
 		Completed:   false,
 		CreatedAt:   time.Now(),
 		UpdatedAt:   time.Now(),

--- a/internal/models/task.go
+++ b/internal/models/task.go
@@ -12,8 +12,8 @@ type Task struct {
 }
 
 type CreateTask struct {
-	Title       string `json:"title"`
-	Description string `json:"description"`
+	Title       *string `json:"title"`
+	Description *string `json:"description"`
 }
 
 type UpdateTask struct {


### PR DESCRIPTION
**Changes**

- feat: added `ClientError` interface
- feat: added `MissingBodyPropertyError` error that implements `ClientError` for handling bad requests related to missing `title` or `description` in the payload.
- feat: added error handling middleware `HandleErrors`: Handles `ClientError` garcefully and unexpected errors are logged
- update: `CreateTask` model has pointers to `Title` and `Description` for nil check

**Issues**

This PR is related to the enhancement for the issue: https://github.com/Arup3201/gotasks/issues/10

**Error Structure**

Errors follow the following structure:

```json
{
    "type": "https://problems-registry.smartbear.com/missing-body-property",
    "title": "Missing body property",
    "detail": "The request is missing an expected body property.",
    "status": 400,
    "code": "400-09",
}
```

All the errors has this structure common, but optionally they can have additional information for the error. Like, the `MissingBodyPropertyError` has:

```json
{
    "type": "https://problems-registry.smartbear.com/missing-body-property",
    "title": "Missing body property",
    "detail": "The request is missing an expected body property.",
    "status": 400,
    "code": "400-09",
    "errors": [
        {
            "detail": "The body property {name} is required",
            "pointer": "#/name"
        }
     ]        
}
```

This structure is taken from https://problems-registry.smartbear.com/missing-body-property/ and it follows https://tools.ietf.org/html/rfc7807.